### PR TITLE
fix: Add id-token: write permission to workflows

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -20,6 +20,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -17,6 +17,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: anthropics/claude-code-action@v1
@@ -77,6 +78,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## 問題
Claude Code Actionワークフローが以下のエラーで失敗していました:
```
Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?
```

## 修正内容
両方のワークフローに `id-token: write` パーミッションを追加:
- `.github/workflows/claude-auto-implement.yml`
- `.github/workflows/claude-auto-review.yml`

## 影響
この修正により、Claude Code ActionがGitHub OIDCトークンを正常に取得できるようになり、Issue自動実装とPR自動レビューが動作するようになります。

## テスト
マージ後、Issue #1のラベルを再付与してワークフローをテストします。