### PR TITLE
fix: Add checkout step to Claude Code Action workflows

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -23,6 +23,10 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -20,6 +20,8 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -81,6 +83,8 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## 問題
Claude Code Actionワークフローが空のディレクトリを見ていたため、実装ができていませんでした。

Claudeからの応答:
> The directory appears to be empty...

## 原因
`actions/checkout@v4`ステップが不足していたため、リポジトリのコードがチェックアウトされていませんでした。

## 修正内容
全てのジョブに`actions/checkout@v4`を追加:
- claude-auto-implement.yml: 実装ジョブ
- claude-auto-review.yml: レビュージョブ、レスポンスジョブ

## テスト
マージ後、Issue #1のラベルを再付与してテストします。