### PR TITLE
fix: Codexレビュー指摘事項の修正(ワークフロー)

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -10,9 +10,9 @@ jobs:
   claude-implement:
     # "claude-implement"ラベル、@claude[bot]へのアサイン、または@claudeメンションで起動
     if: |
-      (github.event.label.name == 'claude-implement') ||
-      (github.event.issue.assignee.login == 'claude[bot]') ||
-      (contains(github.event.comment.body, '@claude') && github.event.issue != null)
+      (github.event.label && github.event.label.name == 'claude-implement') ||
+      (github.event.issue.assignee && github.event.issue.assignee.login == 'claude[bot]') ||
+      (github.event.comment && contains(github.event.comment.body, '@claude') && github.event.issue != null)
 
     runs-on: ubuntu-latest
 
@@ -20,12 +20,11 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: dev
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -17,7 +17,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +79,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
CodexによるGitHub Actionsワークフローレビューで指摘された問題を修正しました。

## 修正内容

### 🔴 High優先度(致命的なバグ)

#### 1. null参照エラーの修正
異なるイベントタイプでnullになるプロパティへのアクセスでワークフローが失敗する問題を修正。

**修正箇所:**
```yaml
# Before (エラー発生)
if: |
  (github.event.label.name == 'claude-implement') ||
  (github.event.issue.assignee.login == 'claude[bot]') ||
  (contains(github.event.comment.body, '@claude') && github.event.issue \!= null)

# After (nullチェック追加)
if: |
  (github.event.label && github.event.label.name == 'claude-implement') ||
  (github.event.issue.assignee && github.event.issue.assignee.login == 'claude[bot]') ||
  (github.event.comment && contains(github.event.comment.body, '@claude') && github.event.issue \!= null)
```

**影響:**
- `labeled`イベント時: `comment`がnullなのに`contains()`でエラー
- `issue_comment`イベント時: `label`がnullなのに`.name`でエラー
- `assigned`イベント時: 両方nullでエラー

#### 2. checkoutブランチの不整合修正
`base_branch: dev`と指定しているのに`default_branch(main)`をチェックアウトしていた問題を修正。

**修正箇所:**
```yaml
# Before
- uses: actions/checkout@v4
  with:
    ref: ${{ github.event.repository.default_branch }}  # main

# After
- uses: actions/checkout@v4
  with:
    ref: dev  # base_branchと一致
```

**影響:** 
- Claudeがmainブランチのコードを見てdevブランチ向けPRを作成するという不整合
- devブランチの最新コードが反映されない

### 🟡 Medium/Low優先度

#### 3. 不要な`id-token: write`権限の削除
最小権限の原則に従い、使用していないOIDC権限を削除。

**理由:**
- 実際にはOAuth tokenを使用しているためOIDCトークンは不要
- セキュリティベストプラクティスに準拠

## Codexレビュー結果

```
✅ High優先度: 2件修正
✅ Medium/Low優先度: 1件修正
```

## テスト
マージ後、Issue #1のラベルを再付与して動作確認します。