### PR TITLE
fix: id-token:write復元とdevelopブランチ使用

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -20,16 +20,17 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: develop
 
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          base_branch: dev  # devブランチベースで作業
+          base_branch: develop  # developブランチベースで作業
           prompt: |
             このIssueで要求されている機能または修正を実装してください。
 

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -17,6 +17,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -79,6 +80,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 問題

### 1. id-token:write権限は必要だった
Codexレビューで「不要」と判断して削除しましたが、実際には**OAuthトークン使用時もOIDC認証が必要**でした。

**エラーログ:**
```
Failed to get OIDC token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

### 2. devブランチが存在しない
実際のブランチ名は`develop`なのに`dev`を指定していました。

**エラーログ:**
```
A branch or tag with the name 'dev' could not be found
```

## 修正内容

### ✅ id-token:write権限を復元
全ジョブに`id-token: write`を追加:
- `claude-implement` (自動実装)
- `claude-review` (PR自動レビュー)  
- `claude-respond` (レビューコメント対応)

### ✅ dev → develop に変更
```yaml
# Before
ref: dev
base_branch: dev

# After  
ref: develop
base_branch: develop
```

## 影響
- これでClaudeがdevelopブランチの最新コードを参照して実装できます
- OIDCトークン取得が正常に動作します

## テスト
マージ後、Issue #1のラベルを再付与してテストします。