### PR TITLE
fix: Issue情報をClaudeに渡す

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -32,7 +32,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: develop  # developブランチベースで作業
           prompt: |
-            このIssueで要求されている機能または修正を実装してください。
+            以下のIssueで要求されている機能または修正を実装してください。
+
+            ## Issue情報
+            - Issue番号: #${{ github.event.issue.number }}
+            - タイトル: ${{ github.event.issue.title }}
+            - 本文:
+            ${{ github.event.issue.body }}
 
             【必須要件】
             - CLAUDE.mdのプロジェクト憲法とコーディング規約に従うこと


### PR DESCRIPTION
## 問題
Claudeが実行されたものの、Issue内容を認識できておらず、「どのIssueに取り組むべきか教えてください」と質問していました。

**Claudeからの応答:**
> どのIssueに取り組むべきかを確認するために...特定のIssue番号をお持ちの場合は、その番号を教えてください

## 原因
ワークフローのプロンプトにIssue情報が含まれていませんでした。

## 修正内容
プロンプトに以下の情報を追加:
```yaml
prompt: |
  以下のIssueで要求されている機能または修正を実装してください。

  ## Issue情報
  - Issue番号: #${{ github.event.issue.number }}
  - タイトル: ${{ github.event.issue.title }}
  - 本文:
  ${{ github.event.issue.body }}

  【必須要件】
  ...
```

## 影響
これでClaudeがIssueの内容を正しく理解して実装できるようになります。

## テスト
マージ後、Issue #1のラベルを再付与してテストします。