### PR TITLE
fix: 承認不要ポリシーを追加

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -61,3 +61,4 @@ jobs:
           claude_args: |
             --max-turns 15
             --model claude-sonnet-4-5
+            --approval-policy never


### PR DESCRIPTION
## 問題
Claudeが実装を試みましたが、`git checkout -b`コマンドで承認が必要になり、そこで処理が止まってしまいました。

**Claudeからの応答:**
> 承認をお待ちしています。ブランチの作成とファイル編集の権限が必要です。

## 原因
自動実装モードでは全てのコマンドを承認なしで実行する必要がありますが、デフォルトでは一部のコマンドに承認が必要でした。

## 修正内容
`claude_args`に`--approval-policy never`を追加:

```yaml
claude_args: |
  --max-turns 15
  --model claude-sonnet-4-5
  --approval-policy never
```

## 影響
これでClaudeが承認なしで全てのコマンドを実行し、自動実装→PR作成まで完結できるようになります。

## テスト
マージ後、Issue #1のラベルを再付与してテストします。