### PR TITLE
feat: Enable full automation with --dangerously-skip-permissions

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -68,4 +68,4 @@ jobs:
           claude_args: |
             --max-turns 15
             --model claude-sonnet-4-5
-            --full-auto
+            --dangerously-skip-permissions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,23 +80,41 @@ MCPツールとして、Claude Code内から直接呼び出し可能です。
 - `config`パラメータで`model`を指定すると応答が返ってこない
 
 ### Claude Code Action (GitHub統合)
-PRを作成すると、GitHub上の別のClaude Codeインスタンスが自動レビューを実施します。
+GitHub Issueから自動実装、PRレビューまでを自動化します。
+
+#### Issue自動実装について
+Issueに`claude-implement`ラベルを付けると:
+- GitHub Actions上で別のClaude Codeが起動（`--dangerously-skip-permissions`で完全自動実行）
+- Issueの要求に基づいてコード実装
+- 新しいブランチを作成してPRを自動作成
+- **環境変数なし**のサンドボックス環境で動作（セキュリティ確保）
+
+#### GitHub Actions環境での安全ルール
+**GitHub ActionsのClaude Codeが従うべき制約**:
+
+✅ **変更可能範囲**:
+- `src/`ディレクトリ内のTypeScriptファイル
+- `docs/`ディレクトリ内のMarkdownファイル
+- テストファイル（`__tests__/`, `*.test.ts`）
+
+❌ **絶対に禁止**:
+- APIキーやトークンをコード内にハードコードしない
+- 環境変数(`process.env`)全体をログ出力しない
+- `.env`ファイルを新規作成しない（環境変数を使用すること）
+- `.gitignore`に含まれるファイルを新規作成してコミットしない
+- `.github/workflows/`の変更（ワークフロー自己改変の禁止）
+- `package.json`の依存関係変更（セキュリティリスク）
 
 #### PR自動レビューについて
-実装完了後、PRを作成すると:
+PRを作成すると:
 - GitHub Actionsで別のClaude Codeが起動
 - 本プロジェクトの品質基準（CLAUDE.md）に基づいてレビュー
 - TypeScript型安全性、エラーハンドリング、セキュリティなどをチェック
 - コメントで指摘・改善提案を受け取る
 
-#### レビュー後の対応
-- レビューコメントの指摘事項を確認
-- 修正が必要な場合は対応してコミット
-- GitHub上のClaudeからの提案を真摯に受け止める
-- 追加の質問があればPRコメントで`@claude`メンション可能
-
 #### ワークフロー
-- `.github/workflows/claude-auto-review.yml`: PR自動レビュー設定
+- `.github/workflows/claude-auto-implement.yml`: Issue自動実装
+- `.github/workflows/claude-auto-review.yml`: PR自動レビュー
 - 詳細: [docs/CLAUDE_CODE_ACTION_GUIDE.md](/docs/CLAUDE_CODE_ACTION_GUIDE.md)
 
 #### レビュープロセス（重要）


### PR DESCRIPTION
## 概要
GitHub ActionsのClaude Code自動実装を完全自動化しました。

## 主な変更

### 1. `--dangerously-skip-permissions`フラグの使用
- `--full-auto`を`--dangerously-skip-permissions`に修正
- GitHub Actions環境で承認プロンプトなしで自動実装が完了

### 2. CLAUDE.mdに安全ルールを追加
GitHub ActionsのClaude Codeが従うべき制約を明記:

**変更可能範囲**:
- `src/`ディレクトリ内のTypeScriptファイル
- `docs/`ディレクトリ内のMarkdownファイル  
- テストファイル

**絶対禁止**:
- APIキーのハードコード
- ワークフロー自己改変（`.github/workflows/`の変更）
- `package.json`依存関係変更
- `.gitignore`ファイルの新規作成

## セキュリティ確保

### 多層防御
1. **サンドボックス環境**: GitHub Actionsは隔離された使い捨て環境
2. **環境変数なし**: POE_API_KEY、DISCORD_TOKENなどのSecretsへアクセス不可
3. **最小権限**: `contents: write`, `pull-requests: write`のみ
4. **PRレビュー**: ローカルClaude CodeとGitHub Claude Codeの二重チェック
5. **人間の最終判断**: マージ前に必ず人間が確認

### リスク分析
- ✅ Secrets流出: **不可能**（環境変数として提供されていない）
- ✅ 外部API誤操作: **不可能**（接続できない）
- ✅ 意図しない変更: PRレビューで検出
- ✅ スコープクリープ: CLAUDE.mdのルールで制約

## 運用フロー
1. Issueに`claude-implement`ラベルを付与
2. GitHub ActionsのClaudeが自動実装してPR作成
3. ローカルClaudeがPRをレビュー
4. 問題なければマージ

## テスト
Issue #10で動作確認予定

## 関連PR
- PR #9 (developブランチ向け)
- PR #11, #12 (前回の試行錯誤)