### PR TITLE
Release: Server profile support and test helpers

### DIFF
--- a/src/discord/messageDispatcher.ts
+++ b/src/discord/messageDispatcher.ts
@@ -113,11 +113,15 @@ export class MessageDispatcher {
   ): EmbedBuilder {
     const flag = result.sourceLang === 'ja' ? '🇯🇵→🇨🇳' : '🇨🇳→🇯🇵';
 
+    // サーバープロフィールを優先、DMの場合はグローバルプロフィールにフォールバック
+    const displayName = originalMessage.member?.displayName ?? originalMessage.author.username;
+    const avatarURL = originalMessage.member?.displayAvatarURL() ?? originalMessage.author.displayAvatarURL();
+
     return new EmbedBuilder()
       .setColor(0x5865f2) // Discordブルー
       .setAuthor({
-        name: originalMessage.author.username,
-        iconURL: originalMessage.author.displayAvatarURL(),
+        name: displayName,
+        iconURL: avatarURL,
       })
       .setDescription(result.translatedText)
       .setFooter({

--- a/src/utils/test-helper.ts
+++ b/src/utils/test-helper.ts
@@ -1,0 +1,33 @@
+/**
+ * テスト用ヘルパー関数
+ * @module utils/test-helper
+ */
+
+/**
+ * 文字列が空かどうかをチェック
+ * @param str - チェック対象の文字列
+ * @returns 文字列が空または空白文字のみの場合true、それ以外はfalse
+ * @example
+ * isEmpty('') // true
+ * isEmpty('  ') // true
+ * isEmpty(null) // true
+ * isEmpty(undefined) // true
+ * isEmpty('hello') // false
+ */
+export function isEmpty(str: string | null | undefined): boolean {
+  return !str || str.trim().length === 0;
+}
+
+/**
+ * 配列が空かどうかをチェック
+ * @param arr - チェック対象の配列
+ * @returns 配列が存在しないまたは要素数が0の場合true、それ以外はfalse
+ * @example
+ * isArrayEmpty([]) // true
+ * isArrayEmpty(null) // true
+ * isArrayEmpty(undefined) // true
+ * isArrayEmpty([1, 2, 3]) // false
+ */
+export function isArrayEmpty<T>(arr: T[] | null | undefined): boolean {
+  return !arr || arr.length === 0;
+}


### PR DESCRIPTION
## Summary
developブランチからmainへのリリースPRです。以下の機能追加と改善が含まれます。

- **サーバープロフィール対応**: Embedのユーザーアイコンとニックネームをサーバープロフィール優先で表示（Issue #1）
- **テストヘルパー関数**: `isEmpty()`と`isArrayEmpty()`の追加（Issue #10）
- **GitHub Actions改善**: 自動実装ワークフローの安定性向上

## Changes
- `src/discord/messageDispatcher.ts`: サーバープロフィールのアイコンとニックネーム表示対応
- `src/discord/messageDispatcher.test.ts`: サーバープロフィールとDMフォールバックのテストケース追加
- `src/utils/test-helper.ts`: 汎用テストヘルパー関数の新規作成

## Test Status
✅ All tests passing (12 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)